### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 To run a Signal TLS proxy, you will need a host with a domain name that has ports 80 and 443 available.
 
-1. Install docker and docker-compose (`apt update && apt install docker docker-compose`)
+1. Install docker and docker-compose (`apt update && apt install docker.io docker-compose`)
 1. Clone this repository
 1. `./init-certificate.sh`
 1. `docker-compose up --detach`


### PR DESCRIPTION
At least on Ubuntu (20.04), the package is called docker.io:

````
$ apt-cache show docker
Package: docker
Architecture: all
Version: 1.5-2
Description-en: transitional package
 This is a transitional package for system tray docking application.
 It can safely be removed.